### PR TITLE
Fixed illegal access of player position.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.8
 
 group = "io.github.lxgaming"
 archivesBaseName = "Sumsang"
-version = "1.14.4-1.2.1"
+version = "forge-1.15.1-30.0.36"
 
 minecraft {
     mappings(channel: "snapshot", version: "20190719-1.14.3")
@@ -56,7 +56,7 @@ repositories {
 }
 
 dependencies {
-    minecraft("net.minecraftforge:forge:1.14.4-28.1.0")
+    minecraft("net.minecraftforge:forge:1.15.1-30.0.36")
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ targetCompatibility = 1.8
 
 group = "io.github.lxgaming"
 archivesBaseName = "Sumsang"
-version = "forge-1.15.1-30.0.36"
+version = "forge-1.15.1-1.2.1"
 
 minecraft {
     mappings(channel: "snapshot", version: "20190719-1.14.3")

--- a/src/main/java/io/github/lxgaming/sumsang/item/NalaxyGote7Item.java
+++ b/src/main/java/io/github/lxgaming/sumsang/item/NalaxyGote7Item.java
@@ -59,7 +59,7 @@ public class NalaxyGote7Item extends Item {
                 Toolbox.grantAdvancement(player, OVER_9000_ADVANCEMENT);
             }
             
-            world.createExplosion(null, player.posX, player.posY, player.posZ, (explosivePower / 10), true, Explosion.Mode.DESTROY);
+            world.createExplosion(null, player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), (explosivePower / 10), true, Explosion.Mode.DESTROY);
         }
         
         int poisonTime = Sumsang.getInstance().getConfiguration().getPoisonTime().get();


### PR DESCRIPTION
The member variables for the player Entity have been made private.
Access now seems to be through getters. Such as Entity.getPosition().getX()

Tested under version 1.15.1